### PR TITLE
Don't add a colon if there is no password

### DIFF
--- a/index.js
+++ b/index.js
@@ -197,7 +197,11 @@ URL.prototype.toString = function toString(stringify) {
     , url = this
     , result = url.protocol +'//';
 
-  if (url.username) result += url.username +':'+ url.password +'@';
+  if (url.username) {
+    result += url.username;
+    if (url.password) result += ':'+ url.password;
+    result += '@';
+  }
 
   result += url.hostname;
   if (url.port) result += ':'+ url.port;

--- a/test.js
+++ b/test.js
@@ -197,6 +197,7 @@ describe('url-parse', function () {
       assume(parsed.username).equals('user');
       assume(parsed.protocol).equals('http:');
       assume(parsed.hostname).equals('www.example.com');
+      assume(parsed.href).equals(url);
     });
   });
 


### PR DESCRIPTION
When a parsed URL with basic auth credentials is transformed back to a string, using `url.href` or `url.toString()`, a colon is always added in the credentials, even if the original URL does not include a password.

This ensures that the colon is not added when there is no password.

Before:
```js
> var parse = require('./')
undefined
> parse('http://foo@loacalhost').href
'http://foo:@loacalhost'
```
After:
```js
> var parse = require('url-parse')
undefined
> parse('http://foo@loacalhost').href
'http://foo@loacalhost'
```