### PR TITLE
Use qs.parse if parser undefined

### DIFF
--- a/index.js
+++ b/index.js
@@ -66,7 +66,7 @@ function URL(address, location, parser) {
     location = null;
   }
 
-  if (parser && 'function' !== typeof parser) {
+  if (!parser || 'function' !== typeof parser) {
     parser = qs.parse;
   }
 


### PR DESCRIPTION
It was failing to parse query strings in tests run on node. This change seems to make it work for me, perhaps it's what you had in mind with the original condition?