### PR TITLE
Specify the arguments taken by the `URL` constructor

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # url-parse
+
 [![Made by unshift](https://img.shields.io/badge/made%20by-unshift-00ffcc.svg?style=flat-square)](http://unshift.io)[![Version npm](https://img.shields.io/npm/v/url-parse.svg?style=flat-square)](http://browsenpm.org/package/url-parse)[![Build Status](https://img.shields.io/travis/unshiftio/url-parse/master.svg?style=flat-square)](https://travis-ci.org/unshiftio/url-parse)[![Dependencies](https://img.shields.io/david/unshiftio/url-parse.svg?style=flat-square)](https://david-dm.org/unshiftio/url-parse)[![Coverage Status](https://img.shields.io/coveralls/unshiftio/url-parse/master.svg?style=flat-square)](https://coveralls.io/r/unshiftio/url-parse?branch=master)[![IRC channel](https://img.shields.io/badge/IRC-irc.freenode.net%23unshift-00a8ff.svg?style=flat-square)](https://webchat.freenode.net/?channels=unshift)
 
 [![Sauce Test Status](https://saucelabs.com/browser-matrix/url-parse.svg)](https://saucelabs.com/u/url-parse)
@@ -8,15 +9,16 @@ The `url-parse` method exposes two different API interfaces. The
 and the new [`URL`](https://developer.mozilla.org/en-US/docs/Web/API/URL/URL)
 interface that is available in the latest browsers.
 
-Since `0.1` we've moved away from using the DOM's `<a>` element for URL parsing
-and moving to a full Regular Expression solution. The main reason for this
-change is to make the URL parser available in different JavaScript environments
-as you don't always have access to the DOM like `Worker` environments. This
-module still have a really small foot print as this module's main intention is
-to be bundled with client-side code. The only problem however with a RegExp
-based solution is that it required a lot of lookups causing major problems in
-FireFox. So the last and the current solution was a pure string parsing
-solution which chops up the URL in smaller pieces.
+In version `0.1` we moved from a DOM based parsing solution, using the `<a>`
+element, to a full Regular Expression solution. The main reason for this was
+to make the URL parser available in different JavaScript environments as you
+don't always have access to the DOM. An example of such environment is the
+[`Worker`](https://developer.mozilla.org/en/docs/Web/API/Worker) interface.
+The RegExp based solution didn't work well as it required a lot of lookups
+causing major problems in FireFox. In version `1.0.0` we ditched the RegExp
+based solution in favor of a pure string parsing solution which chops up the
+URL into smaller pieces. This module still has a really small footprint as it
+has been designed to be used on the client side.
 
 In addition to URL parsing we also expose the bundled `querystringify` module.
 
@@ -47,9 +49,21 @@ var url = new URL('https://github.com/foo/bar');
 ```
 
 The `new` keyword is optional but it will save you an extra function invocation.
-In the example above we've demonstrated the URL interface, but as said in the
-module description we also support the node.js interface. So you could also use
-the library in this way:
+The constructor takes the following arguments:
+
+- `url` (`String`): A string representing an absolute or relative URL.
+- `baseURL` (`Object` | `String`): An object or string representing
+  the base URL to use in case `address` is a relative URL. This argument is
+  optional and defaults to [`location`](https://developer.mozilla.org/en-US/docs/Web/API/Location)
+  in the browser.
+- `parser` (`Boolean` | `Function`): This argument is optional and specifies
+  how to parse the query string. By default it is `false` so the query string
+  is not parsed. If you pass `true` the query string is parsed using the
+  embedded `querystringify` module. If you pass a function the query string
+  wull be parsed using this function.
+
+As said above we also support the node.js interface. So you can also use the
+library in this way:
 
 ```js
 'use strict';
@@ -108,14 +122,11 @@ will automatically update.
 
 The testing of this module is done in 3 different ways:
 
-1. We have unit tests setup which run under Node.js using the normal `npm test`
-   command.
-2. Code coverage can be run manually using `npm run coverage`
-3. For browser testing we use `testling` to startup a test server. We do assume
-   that you `testling` installed globally, if not please run `npm install -g
-   testling` and after that `testling -u` in the root of this repository. When
-   you visit the outputted URL all unit tests that were written from the Node
-   can now be ran inside browsers.
+1. We have unit tests that run under Node.js. You can run these test with the
+  `npm test` command.
+2. Code coverage can be run manually using `npm run coverage`.
+3. For browser testing we use Sauce Labs and `zuul`. You can run browser tests
+  using the `npm run test-browser` command.
 
 ## License
 

--- a/index.js
+++ b/index.js
@@ -35,8 +35,8 @@ var instructions = [
  *
  * @constructor
  * @param {String} address URL we want to parse.
- * @param {Boolean|function} parser Parser for the query string.
- * @param {Object} location Location defaults for relative paths.
+ * @param {Object|String} location Location defaults for relative paths.
+ * @param {Boolean|Function} parser Parser for the query string.
  * @api public
  */
 function URL(address, location, parser) {

--- a/lolcation.js
+++ b/lolcation.js
@@ -19,7 +19,7 @@ var ignore = { hash: 1, query: 1 }
  * encoded in the `pathname` so we can thankfully generate a good "default"
  * location from it so we can generate proper relative URL's again.
  *
- * @param {Object} loc Optional default location object.
+ * @param {Object|String} loc Optional default location object.
  * @returns {Object} lolcation object.
  * @api public
  */


### PR DESCRIPTION
This improves the documentation specifying the arguments taken by the `URL` constructor.

Closes #18.