### PR TITLE
Bump 'assume' devDependency because of failing 'is-node' module

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "requires-port": "1.0.x"
   },
   "devDependencies": {
-    "assume": "1.3.x",
+    "assume": "1.4.x",
     "browserify": "13.0.x",
     "istanbul": "0.4.x",
     "mocha": "2.3.x",

--- a/package.json
+++ b/package.json
@@ -37,8 +37,8 @@
     "assume": "1.4.x",
     "browserify": "13.0.x",
     "istanbul": "0.4.x",
-    "mocha": "2.3.x",
+    "mocha": "2.4.x",
     "pre-commit": "1.1.x",
-    "zuul": "3.9.x"
+    "zuul": "3.10.x"
   }
 }


### PR DESCRIPTION
`assume` no longer depends on `is-node` starting from `v1.4.1`: bigpipe/assume@1ae4779