### PR TITLE
Correctly add missing ":" to protocol in final url string

### DIFF
--- a/index.js
+++ b/index.js
@@ -198,7 +198,11 @@ URL.prototype.toString = function toString(stringify) {
 
   var query
     , url = this
-    , result = url.protocol +'//';
+    , protocol = url.protocol;
+
+  if (protocol && protocol.charAt(protocol.length - 1) !== ':') protocol += ':';
+
+  var result = protocol + '//';
 
   if (url.username) {
     result += url.username;

--- a/test.js
+++ b/test.js
@@ -388,6 +388,20 @@ describe('url-parse', function () {
     });
   });
 
+  it('correctly adds ":" to protocol in final url string', function () {
+    var data = parse('google.com/foo');
+    data.set('protocol', 'https');
+    assume(data.href).equals('https://google.com/foo');
+
+    data = parse('https://google.com/foo');
+    data.protocol = 'http';
+    assume(data.toString()).equals('http://google.com/foo');
+
+    var data = parse('http://google.com/foo');
+    data.set('protocol', 'https:');
+    assume(data.href).equals('https://google.com/foo');
+  });
+
   describe('fuzzy', function () {
     var fuzz = require('./fuzzy')
       , times = 10;


### PR DESCRIPTION
````javascript
const url1 = parse('http://google.com/foo');
const url2 = parse('http://google.com/foo');
url1.set('protocol', 'https:')
url2.set('protocol', 'https')
url1.href === url2.href // should be true
````

This behaviour is also consistent with  Node.js `url` module.

