### PR TITLE
Ensure base location URL slashes are properly parsed

### DIFF
--- a/index.js
+++ b/index.js
@@ -97,10 +97,11 @@ function URL(address, location, parser) {
   location = lolcation(location);
 
   // extract protocol information before running the instructions
-  var extracted = extractProtocol(address);
-  url.protocol = extracted.protocol || location.protocol || '';
-  url.slashes = extracted.slashes || location.slashes;
-  address = extracted.rest;
+  var extractedAddress = extractProtocol(address)
+    , extractedLocation = extractProtocol(location.href);
+  url.protocol = extractedAddress.protocol || extractedLocation.protocol || '';
+  url.slashes = extractedAddress.slashes || extractedLocation.slashes;
+  address = extractedAddress.rest;
 
   for (; i < instructions.length; i++) {
     instruction = instructions[i];

--- a/test.js
+++ b/test.js
@@ -452,6 +452,23 @@ describe('url-parse', function () {
 
       assume(data.href).equals('https://google.com/?foo=bar');
     });
+
+    it('preserves the slashes from a base location object', function () {
+      var base = {
+        search: "",
+        pathname: "/",
+        port: "1234",
+        hostname: "example.com",
+        host: "example.com:1234",
+        protocol: "http:",
+        origin: "http://example.com:1234",
+        href: "http://example.com:1234/",
+        ancestorOrigins: {},
+      };
+      var data = parse('/some/path', base);
+
+      assume(data.href).equals('http://example.com:1234/some/path');
+    });
   });
 
   describe('fuzzy', function () {


### PR DESCRIPTION
This fixes #23, which was caused by the slashes handling not properly pulling slashes from `window.location` if no base location was provided. This defensively extracts the protocol information from the base location to accommodate that case.