### PR TITLE
Fix parsing of slashes property for relative urls

### DIFF
--- a/lolcation.js
+++ b/lolcation.js
@@ -1,8 +1,10 @@
 'use strict';
 
+var slashes = /^[A-Za-z][A-Za-z0-9+-.]*:\/\//;
+
 /**
  * These properties should not be copied or inherited from. This is only needed
- * for all non blob URL's as the a blob URL does not include a hash, only the
+ * for all non blob URL's as a blob URL does not include a hash, only the
  * origin.
  *
  * @type {Object}
@@ -36,9 +38,15 @@ module.exports = function lolcation(loc) {
   } else if ('string' === type) {
     finaldestination = new URL(loc, {});
     for (key in ignore) delete finaldestination[key];
-  } else if ('object' === type) for (key in loc) {
-    if (key in ignore) continue;
-    finaldestination[key] = loc[key];
+  } else if ('object' === type) {
+    for (key in loc) {
+      if (key in ignore) continue;
+      finaldestination[key] = loc[key];
+    }
+
+    if (finaldestination.slashes === undefined) {
+      finaldestination.slashes = slashes.test(loc.href);
+    }
   }
 
   return finaldestination;

--- a/test.js
+++ b/test.js
@@ -278,13 +278,49 @@ describe('url-parse', function () {
       assume(data.href).equals('http://localhost');
     });
 
-    it('does inherit port numbers from relative urls', function () {
+    it('inherits port numbers for relative urls', function () {
       var data = parse('/foo', parse('http://sub.example.com:808/'));
 
       assume(data.port).equals('808');
       assume(data.hostname).equals('sub.example.com');
       assume(data.host).equals('sub.example.com:808');
       assume(data.href).equals('http://sub.example.com:808/foo');
+    });
+
+    it('inherits slashes for relative urls', function () {
+      var data = parse('/foo', {
+        hash: '',
+        host: 'example.com',
+        hostname: 'example.com',
+        href: 'http://example.com/',
+        origin: 'http://example.com',
+        password: '',
+        pathname: '/',
+        port: '',
+        protocol: 'http:',
+        search: ''
+      });
+
+      assume(data.slashes).equals(true);
+      assume(data.href).equals('http://example.com/foo');
+
+      data = parse('/foo', {
+        auth: null,
+        hash: null,
+        host: 'example.com',
+        hostname: 'example.com',
+        href: 'http://example.com/',
+        path: '/',
+        pathname: '/',
+        port: null,
+        protocol: 'http:',
+        query: null,
+        search: null,
+        slashes: true
+      });
+
+      assume(data.slashes).equals(true);
+      assume(data.href).equals('http://example.com/foo');
     });
 
     it('inherits protocol for relative protocols', function () {


### PR DESCRIPTION
Relative URLs are currently incorrectly parsed in the browser because the Location interface does not provide a `slashes` property.

This patch fixes the issue by checking if slashes are used in `location.href`.

The fix is identical to the one provide by @lexi-lambda in #24, but a little cleaner and faster.