### PR TITLE
[Index.js] Removing newline position regex indicator

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,7 +4,7 @@ var required = require('requires-port')
   , lolcation = require('./lolcation')
   , qs = require('querystringify')
   , relativere = /^\/(?!\/)/
-  , protocolre = /^([a-z0-9.+-]+:)?(\/\/)?(.*)$/i; // actual protocol is first match
+  , protocolre = /^([a-z][a-z0-9.+-]*:)?(\/\/)?([\S\s]*)/i; // actual protocol is first match
 
 /**
  * These are the parse instructions for the URL parsers, it informs the parser


### PR DESCRIPTION
dot character matches any character but the new line.
Since urls might be read in text representation, allowing urls that have trailing new lines would be better.

This allows matching urls in this form.
`
"http://foo.bar/\n",
"http://foo.bar/?param=val\nhttp://example.com"
`
which only matches the first line.