### PR TITLE
Update #set('host') to ignore port if missing.

### DIFF
--- a/index.js
+++ b/index.js
@@ -209,13 +209,10 @@ URL.prototype.set = function set(part, value, fn) {
     if (url.port) value += ':'+ url.port;
     url.host = value;
   } else if ('host' === part) {
-    url[part] = value;
-
-    if (/\:\d+/.test(value)) {
-      value = value.split(':');
-      url.hostname = value[0];
-      url.port = value[1];
-    }
+    value = value.split(':');
+    url.hostname = value[0] ? value[0] : url.hostname;
+    url.port = value[1] ? value[1] : url.port;
+    url[part] = url.hostname + ':' + url.port;
   } else if ('protocol' === part) {
     url.protocol = value;
     url.slashes = !fn;

--- a/test.js
+++ b/test.js
@@ -480,6 +480,28 @@ describe('url-parse', function () {
       assume(data.href).equals('http://yahoo.com:808/?foo=bar');
     });
 
+    it('ignores the port when missing from the host', function () {
+      var data = parse('http://google.com:808/?foo=bar');
+
+      assume(data.set('host', 'yahoo.com')).equals(data);
+      assume(data.hostname).equals('yahoo.com');
+      assume(data.host).equals('yahoo.com:808');
+      assume(data.port).equals('808');
+
+      assume(data.href).equals('http://yahoo.com:808/?foo=bar');
+    });
+
+    it('ignores the host when missing from the host', function () {
+      var data = parse('http://google.com:808/?foo=bar');
+
+      assume(data.set('host', ':909')).equals(data);
+      assume(data.hostname).equals('google.com');
+      assume(data.host).equals('google.com:909');
+      assume(data.port).equals('909');
+
+      assume(data.href).equals('http://google.com:909/?foo=bar');
+    });
+
     it('updates the host when updating hostname', function () {
       var data = parse('http://google.com:808/?foo=bar');
 
@@ -492,7 +514,7 @@ describe('url-parse', function () {
       assume(data.href).equals('http://yahoo.com:808/?foo=bar');
     });
 
-    it('updates slashes when updating protocol', function() {
+    it('updates slashes when updating protocol', function () {
       var data = parse('sip:alice@atlanta.com');
 
       assume(data.set('protocol', 'https')).equals(data);


### PR DESCRIPTION
Ignores hostname or port if missing from passed value.

valid values:
`:port`
`hostname:port`
`hostname`

Leaves the port set to previous value if missing from passed value.
Leaves the host set to previous value of missing from passed value.

Fixes #30