### PR TITLE
Update #set('host', url) for missing ports.

### DIFF
--- a/index.js
+++ b/index.js
@@ -211,7 +211,7 @@ URL.prototype.set = function set(part, value, fn) {
   } else if ('host' === part) {
     url[part] = value;
 
-    if (/\:\d+$/.test(value)) {
+    if (/:\d+$/.test(value)) {
       value = value.split(':');
       url.port = value.pop();
       url.hostname = value.join(':');

--- a/index.js
+++ b/index.js
@@ -211,10 +211,13 @@ URL.prototype.set = function set(part, value, fn) {
   } else if ('host' === part) {
     url[part] = value;
 
-    if (/\:\d+/.test(value)) {
+    if (/\:\d+$/.test(value)) {
       value = value.split(':');
-      url.hostname = value[0];
-      url.port = value[1];
+      url.port = value.pop();
+      url.hostname = value.join(':');
+    } else {
+      url.hostname = value;
+      url.port = '';
     }
   } else if ('protocol' === part) {
     url.protocol = value;

--- a/test.js
+++ b/test.js
@@ -480,6 +480,42 @@ describe('url-parse', function () {
       assume(data.href).equals('http://yahoo.com:808/?foo=bar');
     });
 
+    it('updates the port when updating host (IPv6)', function () {
+      var data = parse('http://google.com/?foo=bar');
+
+      assume(data.set('host', '[56h7::1]:808')).equals(data);
+
+      assume(data.hostname).equals('[56h7::1]');
+      assume(data.host).equals('[56h7::1]:808');
+      assume(data.port).equals('808');
+
+      assume(data.href).equals('http://[56h7::1]:808/?foo=bar');
+    });
+
+    it.skip('unsets the port when port is missing (IPv6)', function () {
+      var data = parse('http://google.com/?foo=bar');
+
+      assume(data.set('host', '56h7::1')).equals(data);
+
+      assume(data.hostname).equals('56h7::1');
+      assume(data.host).equals('56h7::1');
+      assume(data.port).equals('');
+
+      assume(data.href).equals('http://[56h7::1]/?foo=bar');
+    });
+
+    it('unsets the port when the port is missing from host', function () {
+      var data = parse('http://google.com:8000/?foo=bar');
+
+      assume(data.set('host', 'yahoo.com')).equals(data);
+
+      assume(data.hostname).equals('yahoo.com');
+      assume(data.host).equals('yahoo.com');
+      assume(data.port).equals('');
+
+      assume(data.href).equals('http://yahoo.com/?foo=bar');
+    });
+
     it('updates the host when updating hostname', function () {
       var data = parse('http://google.com:808/?foo=bar');
 

--- a/test.js
+++ b/test.js
@@ -492,13 +492,13 @@ describe('url-parse', function () {
       assume(data.href).equals('http://[56h7::1]:808/?foo=bar');
     });
 
-    it.skip('unsets the port when port is missing (IPv6)', function () {
+    it('unsets the port when port is missing (IPv6)', function () {
       var data = parse('http://google.com/?foo=bar');
 
-      assume(data.set('host', '56h7::1')).equals(data);
+      assume(data.set('host', '[56h7::1]')).equals(data);
 
-      assume(data.hostname).equals('56h7::1');
-      assume(data.host).equals('56h7::1');
+      assume(data.hostname).equals('[56h7::1]');
+      assume(data.host).equals('[56h7::1]');
       assume(data.port).equals('');
 
       assume(data.href).equals('http://[56h7::1]/?foo=bar');


### PR DESCRIPTION
Increases reliability of `.set('host', url)` for `url`s missing the port.
`hostname` propagation still happens when the port is not present.
Increases IPv6 support with brackets.

Skipped (failing) test case added - IPv6 without brackets will fail,
as it doesn't recognize if the address is shortened or not. A full
address with 8 octets will be parsed as 7.

Fixes #30 