### PR TITLE
IPv6 Hostname

### DIFF
--- a/fuzzy.js
+++ b/fuzzy.js
@@ -30,15 +30,17 @@ combinations.hostname = [
   'xn--n3h.com',
   'localhost',
   '127.0.0.1',
-  '255.255.255.255'/*,
-  '3ffe:6a88:85a3:08d3:1319:8a2e:0370:7344',
-  '2001:2353::1428:57ab',
-  '2001:2353:0::0:1428:57ab',
-  '2001:2353:0:0:0:0:1428:57ab',
-  '2001:2353:0000:0000:0000::1428:57ab',
-  '2001:2353:0000:0000:0000:0000:1428:57ab',
-  '2001:2353:02de::0e13',
-  '2001:2353:2de::e13'*/
+  '255.255.255.255',
+  '[3ffe:6a88:85a3:08d3:1319:8a2e:0370:7344]',
+  '[2001:2353::1428:57ab]',
+  '[2001:2353:0::0:1428:57ab]',
+  '[2001:2353:0:0:0:0:1428:57ab]',
+  '[2001:2353:0000:0000:0000::1428:57ab]',
+  '[2001:2353:0000:0000:0000:0000:1428:57ab]',
+  '[2001:2353:02de::0e13]',
+  '[2001:2353:2de::e13]',
+  '[::2]',
+  '[1::]'
 ];
 combinations.port = ['8080', '844', '3340'];
 combinations.pathname = [
@@ -110,6 +112,9 @@ module.exports = function generate() {
     spec.username = get('username');
     spec.password = get('password');
   }
+
+  spec.host = spec.port ? spec.hostname + ':' + spec.port : spec.hostname;
+  if (URL.isIPv6(spec.hostname)) spec.hostname = spec.hostname.slice(1, -1);
 
   for (key in combinations) {
     url[key] = '';

--- a/index.js
+++ b/index.js
@@ -61,7 +61,7 @@ function extractProtocol(address) {
  * @api private
  */
 function isIPv6(hostname) {
-  return hostname[0] === '[' && hostname[hostname.length - 1] === ']';
+  return (hostname[0] === '[' && hostname[hostname.length - 1] === ']') || /:/.test(hostname);
 }
 
 /**
@@ -177,7 +177,7 @@ function URL(address, location, parser) {
     url.password = instruction[1] || '';
   }
 
-  // IPv6 - remove brackets from hostname
+  // Remove brackets from IPv6 hostname
   if (isIPv6(url.hostname)) url.hostname = url.hostname.slice(1, -1);
 
   //
@@ -212,14 +212,15 @@ URL.prototype.set = function set(part, value, fn) {
     url[part] = value;
 
     if (!required(value, url.protocol)) {
-      url.host = url.hostname;
+      url.host = isIPv6(url.hostname) ? '['+ url.hostname +']' : url.hostname;
       url[part] = '';
     } else if (value) {
-      url.host = url.hostname +':'+ value;
+      url.host = isIPv6(url.hostname) ? '['+ url.hostname +']' +':'+ value : url.hostname +':'+ value;
     }
   } else if ('hostname' === part) {
     url[part] = value;
 
+    // Remove brackets from IPv6 hostname
     if (isIPv6(url.hostname)) url.hostname = url.hostname.slice(1, -1);
 
     if (url.port) value += ':'+ url.port;

--- a/index.js
+++ b/index.js
@@ -54,6 +54,17 @@ function extractProtocol(address) {
 }
 
 /**
+ * Check for IPv6 formatted hostname
+ *
+ * @param  {String}  hostname hostname
+ * @return {Boolean}          Whether or not the hostname is IPv6
+ * @api private
+ */
+function isIPv6(hostname) {
+  return hostname[0] === '[' && hostname[hostname.length - 1] === ']';
+}
+
+/**
  * The actual URL instance. Instead of returning an object we've opted-in to
  * create an actual constructor as it's much more memory efficient and
  * faster and it pleases my OCD.
@@ -166,6 +177,9 @@ function URL(address, location, parser) {
     url.password = instruction[1] || '';
   }
 
+  // IPv6 - remove brackets from hostname
+  if (isIPv6(url.hostname)) url.hostname = url.hostname.slice(1, -1);
+
   //
   // The href is just the compiled result.
   //
@@ -206,6 +220,8 @@ URL.prototype.set = function set(part, value, fn) {
   } else if ('hostname' === part) {
     url[part] = value;
 
+    if (isIPv6(url.hostname)) url.hostname = url.hostname.slice(1, -1);
+
     if (url.port) value += ':'+ url.port;
     url.host = value;
   } else if ('host' === part) {
@@ -219,6 +235,10 @@ URL.prototype.set = function set(part, value, fn) {
       url.hostname = value;
       url.port = '';
     }
+
+    // Remove brackets from IPv6 hostname
+    if (isIPv6(url.hostname)) url.hostname = url.hostname.slice(1, -1);
+
   } else if ('protocol' === part) {
     url.protocol = value;
     url.slashes = !fn;
@@ -254,9 +274,7 @@ URL.prototype.toString = function toString(stringify) {
     result += '@';
   }
 
-  result += url.hostname;
-  if (url.port) result += ':'+ url.port;
-
+  result += url.host;
   result += url.pathname;
 
   query = 'object' === typeof url.query ? stringify(url.query) : url.query;
@@ -272,6 +290,7 @@ URL.prototype.toString = function toString(stringify) {
 // others or testing.
 //
 URL.extractProtocol = extractProtocol;
+URL.isIPv6 = isIPv6;
 URL.location = lolcation;
 URL.qs = qs;
 

--- a/index.js
+++ b/index.js
@@ -211,11 +211,12 @@ URL.prototype.set = function set(part, value, fn) {
   } else if ('port' === part) {
     url[part] = value;
 
+    var host = isIPv6(url.hostname) ? '['+ url.hostname +']' : url.hostname;
     if (!required(value, url.protocol)) {
-      url.host = isIPv6(url.hostname) ? '['+ url.hostname +']' : url.hostname;
+      url.host = host;
       url[part] = '';
     } else if (value) {
-      url.host = isIPv6(url.hostname) ? '['+ url.hostname +']' +':'+ value : url.hostname +':'+ value;
+      url.host = host +':'+ value;
     }
   } else if ('hostname' === part) {
     url[part] = value;

--- a/test.js
+++ b/test.js
@@ -217,7 +217,7 @@ describe('url-parse', function () {
       assume(parsed.port).equals('61616');
       assume(parsed.query).equals('?q=z');
       assume(parsed.protocol).equals('http:');
-      assume(parsed.hostname).equals('[1080:0:0:0:8:800:200c:417a]');
+      assume(parsed.hostname).equals('1080:0:0:0:8:800:200c:417a');
       assume(parsed.pathname).equals('/foo/bar');
       assume(parsed.href).equals('http://[1080:0:0:0:8:800:200c:417a]:61616/foo/bar?q=z');
     });
@@ -229,8 +229,17 @@ describe('url-parse', function () {
       assume(parsed.username).equals('user');
       assume(parsed.password).equals('password');
       assume(parsed.host).equals('[3ffe:2a00:100:7031::1]:8080');
-      assume(parsed.hostname).equals('[3ffe:2a00:100:7031::1]');
+      assume(parsed.hostname).equals('3ffe:2a00:100:7031::1');
       assume(parsed.href).equals(url);
+    });
+
+    it('strips the brackets off the hostname but not the host', function () {
+      var url = 'http://[3ffe:2a00:100:7031::1]/foo'
+        , parsed = parse(url);
+
+      assume(parsed.hostname).equals('3ffe:2a00:100:7031::1');
+      assume(parsed.host).equals('[3ffe:2a00:100:7031::1]');
+      assume(parsed.href).equals('http://[3ffe:2a00:100:7031::1]/foo');
     });
 
     it('parses ipv4', function () {
@@ -485,7 +494,7 @@ describe('url-parse', function () {
 
       assume(data.set('host', '[56h7::1]:808')).equals(data);
 
-      assume(data.hostname).equals('[56h7::1]');
+      assume(data.hostname).equals('56h7::1');
       assume(data.host).equals('[56h7::1]:808');
       assume(data.port).equals('808');
 
@@ -497,7 +506,7 @@ describe('url-parse', function () {
 
       assume(data.set('host', '[56h7::1]')).equals(data);
 
-      assume(data.hostname).equals('[56h7::1]');
+      assume(data.hostname).equals('56h7::1');
       assume(data.host).equals('[56h7::1]');
       assume(data.port).equals('');
 
@@ -514,6 +523,18 @@ describe('url-parse', function () {
       assume(data.port).equals('');
 
       assume(data.href).equals('http://yahoo.com/?foo=bar');
+    });
+
+    it('strips brackets from IPv6 hostnames', function () {
+      var data = parse('http://google.com/?foo=bar');
+
+      assume(data.set('hostname', '[2001:db8:a0b:12f0::1]')).equals(data);
+
+      assume(data.hostname).equals('2001:db8:a0b:12f0::1');
+      assume(data.host).equals('[2001:db8:a0b:12f0::1]');
+      assume(data.port).equals('');
+
+      assume(data.href).equals('http://[2001:db8:a0b:12f0::1]/?foo=bar');
     });
 
     it('updates the host when updating hostname', function () {

--- a/test.js
+++ b/test.js
@@ -403,6 +403,15 @@ describe('url-parse', function () {
       assume(data.href).equals('http://google.com:8080/foo');
     });
 
+    it('correctly updates the host when setting port (IPv6)', function () {
+      var data = parse('http://[7886:3423::1233]/foo');
+
+      assume(data.set('port', 8080)).equals(data);
+
+      assume(data.host).equals('[7886:3423::1233]:8080');
+      assume(data.href).equals('http://[7886:3423::1233]:8080/foo');
+    });
+
     it('removes querystring and hash', function () {
       var data = parse('https://thisanurl.com/?swag=yolo#representing');
 
@@ -423,6 +432,19 @@ describe('url-parse', function () {
       assume(data.set('port', 443)).equals(data);
       assume(data.host).equals('google.com:443');
       assume(data.href).equals('http://google.com:443/foo');
+    });
+
+    it('only sets port when its not default (IPv6)', function () {
+      var data = parse('http://[7886:3423::1233]/foo');
+
+      assume(data.set('port', 80)).equals(data);
+
+      assume(data.host).equals('[7886:3423::1233]');
+      assume(data.href).equals('http://[7886:3423::1233]/foo');
+
+      assume(data.set('port', 443)).equals(data);
+      assume(data.host).equals('[7886:3423::1233]:443');
+      assume(data.href).equals('http://[7886:3423::1233]:443/foo');
     });
 
     it('updates query with object', function () {


### PR DESCRIPTION
Adds more support for parsing IPv6 URL's.
Includes changes to the main parse function to remove brackets from IPv6 URL's.

Inspired by:

https://github.com/nodejs/node/blob/a94ffda/lib/url.js#L184
https://github.com/nodejs/node/blob/a94ffda/lib/url.js#L349

