### PR TITLE
Add better support for URLs without an authority component

### DIFF
--- a/fuzzy.js
+++ b/fuzzy.js
@@ -1,7 +1,7 @@
 'use strict';
 
 var URL = require('./')
-  , url = new URL('');
+  , url = new URL('//');
 
 /**
  * A dictionary with all kind of different options that should generate a valid
@@ -16,8 +16,8 @@ combinations.protocol = [
   'http:',
   'https:',
   'ws:',
-  'wss:',
-  'blob:'/*,
+  'wss:'/*,
+  'blob:',
   ''*/
 ];
 combinations.username = ['foo', 'bar'];
@@ -53,9 +53,10 @@ combinations.pathname = [
   '/@3rd-Eden',
   '/a/b/c/d/e/f/g/j/1/d/4/'
 ];
-combinations.query = ['foo=bar',
+combinations.query = [
   'foo[]=bar&foo[]=foo',
   'email=foo@bar.travel',
+  'foo=bar',
   'q='
 ];
 combinations.hash = [

--- a/index.js
+++ b/index.js
@@ -3,11 +3,10 @@
 var required = require('requires-port')
   , lolcation = require('./lolcation')
   , qs = require('querystringify')
-  , relativere = /^\/(?!\/)/
   , protocolre = /^([a-z][a-z0-9.+-]*:)?(\/\/)?([\S\s]*)/i;
 
 /**
- * These are the parse instructions for the URL parsers, it informs the parser
+ * These are the parse rules for the URL parser, it informs the parser
  * about:
  *
  * 0. The char it Needs to parse, if it's a string it should be done using
@@ -18,38 +17,38 @@ var required = require('requires-port')
  * 3. Inherit from location if non existing in the parser.
  * 4. `toLowerCase` the resulting value.
  */
-var instructions = [
+var rules = [
   ['#', 'hash'],                        // Extract from the back.
   ['?', 'query'],                       // Extract from the back.
   ['/', 'pathname'],                    // Extract from the back.
   ['@', 'auth', 1],                     // Extract from the front.
   [NaN, 'host', undefined, 1, 1],       // Set left over value.
-  [/:(\d+)$/, 'port'],                  // RegExp the back.
+  [/:(\d+)$/, 'port', undefined, 1],    // RegExp the back.
   [NaN, 'hostname', undefined, 1, 1]    // Set left over.
 ];
 
- /**
+/**
  * @typedef ProtocolExtract
  * @type Object
- * @property {String} protocol Protocol matched in the URL, in lowercase
- * @property {Boolean} slashes Indicates whether the protocol is followed by double slash ("//")
- * @property {String} rest     Rest of the URL that is not part of the protocol
+ * @property {String} protocol Protocol matched in the URL, in lowercase.
+ * @property {Boolean} slashes `true` if protocol is followed by "//", else `false`.
+ * @property {String} rest Rest of the URL that is not part of the protocol.
  */
 
- /**
-  * Extract protocol information from a URL with/without double slash ("//")
-  *
-  * @param  {String} address   URL we want to extract from.
-  * @return {ProtocolExtract}  Extracted information
-  * @api private
-  */
+/**
+ * Extract protocol information from a URL with/without double slash ("//").
+ *
+ * @param {String} address URL we want to extract from.
+ * @return {ProtocolExtract} Extracted information.
+ * @api private
+ */
 function extractProtocol(address) {
   var match = protocolre.exec(address);
 
   return {
     protocol: match[1] ? match[1].toLowerCase() : '',
     slashes: !!match[2],
-    rest: match[3] ? match[3] : ''
+    rest: match[3]
   };
 }
 
@@ -69,11 +68,10 @@ function URL(address, location, parser) {
     return new URL(address, location, parser);
   }
 
-  var relative = relativere.test(address)
-    , parse, instruction, index, key
+  var relative, extracted, parse, instruction, index, key
+    , instructions = rules.slice()
     , type = typeof location
     , url = this
-    , extracted
     , i = 0;
 
   //
@@ -92,19 +90,24 @@ function URL(address, location, parser) {
     location = null;
   }
 
-  if (parser && 'function' !== typeof parser) {
-    parser = qs.parse;
-  }
+  if (parser && 'function' !== typeof parser) parser = qs.parse;
 
   location = lolcation(location);
 
   //
-  // extract protocol information before running the instructions
+  // Extract protocol information before running the instructions.
   //
   extracted = extractProtocol(address);
+  relative = !extracted.protocol && !extracted.slashes;
+  url.slashes = extracted.slashes || relative && location.slashes;
   url.protocol = extracted.protocol || location.protocol || '';
-  url.slashes = extracted.slashes || location.slashes;
   address = extracted.rest;
+
+  //
+  // When the authority component is absent the URL starts with a path
+  // component.
+  //
+  if (!extracted.slashes) instructions[2] = [/(.*)/, 'pathname'];
 
   for (; i < instructions.length; i++) {
     instruction = instructions[i];
@@ -125,18 +128,18 @@ function URL(address, location, parser) {
       }
     } else if (index = parse.exec(address)) {
       url[key] = index[1];
-      address = address.slice(0, address.length - index[0].length);
+      address = address.slice(0, index.index);
     }
 
-    url[key] = url[key] || (instruction[3] || ('port' === key && relative) ? location[key] || '' : '');
+    url[key] = url[key] || (
+      relative && instruction[3] ? location[key] || '' : ''
+    );
 
     //
     // Hostname, host and protocol should be lowercased so they can be used to
     // create a proper `origin`.
     //
-    if (instruction[4]) {
-      url[key] = url[key].toLowerCase();
-    }
+    if (instruction[4]) url[key] = url[key].toLowerCase();
   }
 
   //
@@ -166,10 +169,13 @@ function URL(address, location, parser) {
     url.password = instruction[1] || '';
   }
 
+  url.origin = url.protocol && url.host && url.protocol !== 'file:'
+    ? url.protocol +'//'+ url.host
+    : 'null';
+
   //
   // The href is just the compiled result.
   //
-  url.origin = url.protocol && url.host && url.protocol !== 'file:' ? url.protocol +'//'+ url.host : 'null';
   url.href = url.toString();
 }
 
@@ -179,10 +185,10 @@ function URL(address, location, parser) {
  *
  * @param {String} part          Property we need to adjust.
  * @param {Mixed} value          The newly assigned value.
- * @param {Boolean|Function} fn  When setting the query, it will be the function used to parse
- *                               the query.
- *                               When setting the protocol, double slash will be removed from
- *                               the final url if it is true.
+ * @param {Boolean|Function} fn  When setting the query, it will be the function
+ *                               used to parse the query.
+ *                               When setting the protocol, double slash will be
+ *                               removed from the final url if it is true.
  * @returns {URL}
  * @api public
  */
@@ -227,15 +233,16 @@ URL.prototype.set = function set(part, value, fn) {
     url[part] = value;
   }
 
-  for (var i = 0; i < instructions.length; i++) {
-    var ins = instructions[i];
+  for (var i = 0; i < rules.length; i++) {
+    var ins = rules[i];
 
-    if (ins[4]) {
-      url[ins[1]] = url[ins[1]].toLowerCase();
-    }
+    if (ins[4]) url[ins[1]] = url[ins[1]].toLowerCase();
   }
 
-  url.origin = url.protocol && url.host && url.protocol !== 'file:' ? url.protocol +'//'+ url.host : 'null';
+  url.origin = url.protocol && url.host && url.protocol !== 'file:'
+    ? url.protocol +'//'+ url.host
+    : 'null';
+
   url.href = url.toString();
 
   return url;

--- a/test.js
+++ b/test.js
@@ -235,16 +235,33 @@ describe('url-parse', function () {
   describe('protocol', function () {
     it('extracts the right protocol from a url', function () {
       var testData = [
-        { url: 'http://example.com', protocol: 'http:' },
-        { url: 'mailto:test@example.com', protocol: 'mailto:' },
-        { url: 'data:text/html,%3Ch1%3EHello%2C%20World!%3C%2Fh1%3E', protocol: 'data:' },
-        { url: 'sip:alice@atlanta.com', protocol: 'sip:' }
+        {
+          href: 'http://example.com',
+          protocol: 'http:',
+          pathname: ''
+        },
+        {
+          href: 'mailto:test@example.com',
+          pathname: 'test@example.com',
+          protocol: 'mailto:'
+        },
+        {
+          href: 'data:text/html,%3Ch1%3EHello%2C%20World!%3C%2Fh1%3E',
+          pathname: 'text/html,%3Ch1%3EHello%2C%20World!%3C%2Fh1%3E',
+          protocol: 'data:'
+        },
+        {
+          href: 'sip:alice@atlanta.com',
+          pathname: 'alice@atlanta.com',
+          protocol: 'sip:'
+        }
       ];
 
       var data;
       for (var i = 0, len = testData.length; i < len; ++i) {
-        data = testData[i];
-        assume(parse(data.url).protocol).equals(data.protocol);
+        data = parse(testData[i].href);
+        assume(data.protocol).equals(testData[i].protocol);
+        assume(data.pathname).equals(testData[i].pathname);
       }
     });
 
@@ -255,7 +272,7 @@ describe('url-parse', function () {
     });
 
     it('correctly adds ":" to protocol in final url string', function () {
-      var data = parse('google.com/foo');
+      var data = parse('google.com/foo', {});
       data.set('protocol', 'https');
       assume(data.href).equals('https://google.com/foo');
 
@@ -270,8 +287,6 @@ describe('url-parse', function () {
   });
 
   describe('ip', function () {
-    // coap://
-    //
     it('parses ipv6', function () {
       var url = 'http://[1080:0:0:0:8:800:200C:417A]:61616/foo/bar?q=z'
         , parsed = parse(url);

--- a/test.js
+++ b/test.js
@@ -433,12 +433,47 @@ describe('url-parse', function () {
       assume(data.href).equals('http://foo.com/foo');
     });
 
-    it('does not inherit pathnames from the source', function () {
+    it('does not inherit pathname for non relative urls', function () {
       var data = parse('http://localhost', parse('http://foo:bar@sub.example.com/bar?foo=bar#hash'));
 
       assume(data.port).equals('');
       assume(data.host).equals('localhost');
       assume(data.href).equals('http://localhost');
+    });
+
+    it('resolves pathname for relative urls', function () {
+      var data, i = 0;
+      var tests = [
+        ['', 'http://foo.com', ''],
+        ['', 'http://foo.com/', '/'],
+        ['a', 'http://foo.com', '/a'],
+        ['a/', 'http://foo.com', '/a/'],
+        ['b/c', 'http://foo.com/a', '/b/c'],
+        ['b/c', 'http://foo.com/a/', '/a/b/c'],
+        ['.', 'http://foo.com', '/'],
+        ['./', 'http://foo.com', '/'],
+        ['./.', 'http://foo.com', '/'],
+        ['.', 'http://foo.com/a', '/'],
+        ['.', 'http://foo.com/a/', '/a/'],
+        ['./', 'http://foo.com/a/', '/a/'],
+        ['./.', 'http://foo.com/a/', '/a/'],
+        ['./b', 'http://foo.com/a/', '/a/b'],
+        ['..', 'http://foo.com', '/'],
+        ['../', 'http://foo.com', '/'],
+        ['../..', 'http://foo.com', '/'],
+        ['..', 'http://foo.com/a/b', '/'],
+        ['..', 'http://foo.com/a/b/', '/a/'],
+        ['../..', 'http://foo.com/a/b', '/'],
+        ['../..', 'http://foo.com/a/b/', '/'],
+        ['../../../../c', 'http://foo.com/a/b/', '/c'],
+        ['./../d', 'http://foo.com/a/b/c', '/a/d'],
+        ['d/e/f/./../../g', 'http://foo.com/a/b/c', '/a/b/d/g']
+      ];
+
+      for (; i < tests.length; i++) {
+        data = parse(tests[i][0], tests[i][1]);
+        assume(data.pathname).equals(tests[i][2]);
+      }
     });
 
     it('does not inherit hashes and query strings from source object', function () {
@@ -450,8 +485,8 @@ describe('url-parse', function () {
     });
 
     it('does not inherit auth from source object', function () {
-      var from = parse('http://foo:bar@sub.example.com')
-        , data = parse('/foo', from);
+      var base = parse('http://foo:bar@sub.example.com')
+        , data = parse('/foo', base);
 
       assume(data.port).equals('');
       assume(data.username).equals('');


### PR DESCRIPTION
Right now URLs without an authority component are not parsed correctly. For example the URL `mailto:fred@example.com` is incorrectly parsed as:
```js
> parse('mailto:fred@example.com')
URL {
  protocol: 'mailto:',
  slashes: false,
  hash: '',
  query: '',
  pathname: '',
  auth: 'fred',
  host: 'example.com',
  port: '',
  hostname: 'example.com',
  password: '',
  username: 'fred',
  origin: 'mailto://example.com',
  href: 'mailto:fred@example.com' }
```
The URL syntax is defined in [RFC 3986](https://tools.ietf.org/html/rfc3986#section-3) as follow:
```
URI         = scheme ":" hier-part [ "?" query ] [ "#" fragment ]

hier-part   = "//" authority path-abempty
            / path-absolute
            / path-rootless
            / path-empty
```
so in the above example the `fred@example.com` part should be parsed as `pathname`.
The browser and the Python `urlparse` module parse those URLs as expected:
```js
new URL('mailto:fred@example.com')
URL {
  href: "mailto:fred@example.com",
  origin: "null",
  protocol: "mailto:",
  username: "",
  password: "",
  host: "",
  hostname: "",
  port: "",
  pathname: "fred@example.com",
  search: ""
}
```
```python
>>> from urlparse import urlparse
>>> o = urlparse('mailto:fred@example.com')
>>> o
ParseResult(scheme='mailto', netloc='', path='fred@example.com', params='', query='', fragment='')
>>> 
```
This patch tries to fix the issue.