### PR TITLE
use `Object.defineProperty` in priority

### DIFF
--- a/index.js
+++ b/index.js
@@ -349,7 +349,7 @@ if (Object.defineProperty) {
   Object.defineProperty(URL.prototype, 'toString', { 
     writable: true,
     enumerable: true,
-    configurable: true
+    configurable: true,
     value: toString
   });
 } else {

--- a/index.js
+++ b/index.js
@@ -345,6 +345,7 @@ function toString(stringify) {
 
   return result;
 }
+
 if (Object.defineProperty) {
   Object.defineProperty(URL.prototype, 'toString', { 
     writable: true,

--- a/index.js
+++ b/index.js
@@ -319,32 +319,34 @@ URL.prototype.set = function set(part, value, fn) {
  * @returns {String}
  * @api public
  */
-URL.prototype.toString = function toString(stringify) {
-  if (!stringify || 'function' !== typeof stringify) stringify = qs.stringify;
+Object.defineProperty(URL.prototype, 'toString', {
+  value: function toString(stringify) {
+    if (!stringify || 'function' !== typeof stringify) stringify = qs.stringify;
 
-  var query
-    , url = this
-    , protocol = url.protocol;
+    var query
+      , url = this
+      , protocol = url.protocol;
 
-  if (protocol && protocol.charAt(protocol.length - 1) !== ':') protocol += ':';
+    if (protocol && protocol.charAt(protocol.length - 1) !== ':') protocol += ':';
 
-  var result = protocol + (url.slashes ? '//' : '');
+    var result = protocol + (url.slashes ? '//' : '');
 
-  if (url.username) {
-    result += url.username;
-    if (url.password) result += ':'+ url.password;
-    result += '@';
+    if (url.username) {
+      result += url.username;
+      if (url.password) result += ':'+ url.password;
+      result += '@';
+    }
+
+    result += url.host + url.pathname;
+
+    query = 'object' === typeof url.query ? stringify(url.query) : url.query;
+    if (query) result += '?' !== query.charAt(0) ? '?'+ query : query;
+
+    if (url.hash) result += url.hash;
+
+    return result;
   }
-
-  result += url.host + url.pathname;
-
-  query = 'object' === typeof url.query ? stringify(url.query) : url.query;
-  if (query) result += '?' !== query.charAt(0) ? '?'+ query : query;
-
-  if (url.hash) result += url.hash;
-
-  return result;
-};
+});
 
 //
 // Expose the URL parser and some additional properties that might be useful for

--- a/index.js
+++ b/index.js
@@ -238,7 +238,7 @@ function URL(address, location, parser) {
  * @returns {URL}
  * @api public
  */
-URL.prototype.set = function set(part, value, fn) {
+function set(part, value, fn) {
   var url = this;
 
   switch (part) {
@@ -346,16 +346,7 @@ function toString(stringify) {
   return result;
 }
 
-if (Object.defineProperty) {
-  Object.defineProperty(URL.prototype, 'toString', { 
-    writable: true,
-    enumerable: true,
-    configurable: true,
-    value: toString
-  });
-} else {
-  URL.prototype.toString = toString;
-}
+URL.prototype = { set: set, toString: toString };
 
 //
 // Expose the URL parser and some additional properties that might be useful for

--- a/index.js
+++ b/index.js
@@ -346,7 +346,12 @@ function toString(stringify) {
   return result;
 }
 if (Object.defineProperty) {
-  Object.defineProperty(URL.prototype, 'toString', { value: toString });
+  Object.defineProperty(URL.prototype, 'toString', { 
+    writable: true,
+    enumerable: true,
+    configurable: true
+    value: toString
+  });
 } else {
   URL.prototype.toString = toString;
 }

--- a/index.js
+++ b/index.js
@@ -319,34 +319,37 @@ URL.prototype.set = function set(part, value, fn) {
  * @returns {String}
  * @api public
  */
-Object.defineProperty(URL.prototype, 'toString', {
-  value: function toString(stringify) {
-    if (!stringify || 'function' !== typeof stringify) stringify = qs.stringify;
+function toString(stringify) {
+  if (!stringify || 'function' !== typeof stringify) stringify = qs.stringify;
 
-    var query
-      , url = this
-      , protocol = url.protocol;
+  var query
+    , url = this
+    , protocol = url.protocol;
 
-    if (protocol && protocol.charAt(protocol.length - 1) !== ':') protocol += ':';
+  if (protocol && protocol.charAt(protocol.length - 1) !== ':') protocol += ':';
 
-    var result = protocol + (url.slashes ? '//' : '');
+  var result = protocol + (url.slashes ? '//' : '');
 
-    if (url.username) {
-      result += url.username;
-      if (url.password) result += ':'+ url.password;
-      result += '@';
-    }
-
-    result += url.host + url.pathname;
-
-    query = 'object' === typeof url.query ? stringify(url.query) : url.query;
-    if (query) result += '?' !== query.charAt(0) ? '?'+ query : query;
-
-    if (url.hash) result += url.hash;
-
-    return result;
+  if (url.username) {
+    result += url.username;
+    if (url.password) result += ':'+ url.password;
+    result += '@';
   }
-});
+
+  result += url.host + url.pathname;
+
+  query = 'object' === typeof url.query ? stringify(url.query) : url.query;
+  if (query) result += '?' !== query.charAt(0) ? '?'+ query : query;
+
+  if (url.hash) result += url.hash;
+
+  return result;
+}
+if (Object.defineProperty) {
+  Object.defineProperty(URL.prototype, 'toString', { value: toString });
+} else {
+  URL.prototype.toString = toString;
+}
 
 //
 // Expose the URL parser and some additional properties that might be useful for


### PR DESCRIPTION
in case of `Uncaught TypeError: Cannot assign to read only property 'toString' of object '[object Object]'` under strict mode.