### PR TITLE
Add typings.

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,33 @@
+declare module "url-parse" {
+    interface Query {
+        [index: string]: string;
+    }
+
+    interface QueryParser {
+        (query: string): any;
+    }
+
+    interface ParsedUrl {
+        (url: string, baseURL?: string, parseQuery?: boolean|QueryParser): ParsedUrl;
+        new (url: string, baseURL?: string, parseQuery?: boolean|QueryParser): ParsedUrl;
+
+        protocol: string;   // protocol: Requested protocol without slashes (e.g. http:).
+        username: string;   // username: Username of basic authentication.
+        password: string;   // password: Password of basic authentication.
+        auth: string;       // auth: Authentication information portion (e.g. username:password).
+        host: string;       // host: Host name with port number.
+        hostname: string;   // hostname: Host name without port number.
+        port: string;       // port: Optional port number.
+        pathname: string;   // pathname: URL path.
+        query: Query;       // query: Parsed object containing query string, unless parsing is set to false.
+        hash: string;       // hash: The "fragment" portion of the URL including the pound-sign (#).
+        href: string;       // href: The full URL.
+
+        toString(): string;
+        set(key: string, value: string|Object|number): ParsedUrl;
+    }
+
+    const URL: ParsedUrl;
+
+    export = URL;
+}

--- a/index.d.ts
+++ b/index.d.ts
@@ -12,9 +12,10 @@ declare module "url-parse" {
         new (url: string, baseURL?: string, parseQuery?: boolean|QueryParser): ParsedUrl;
 
         protocol: string;   // protocol: Requested protocol without slashes (e.g. http:).
+        slashes: boolean;   // slashes: Indicates whether the protocol is followed by two forward slashes (//).
+        auth: string;       // auth: Authentication information portion (e.g. username:password).
         username: string;   // username: Username of basic authentication.
         password: string;   // password: Password of basic authentication.
-        auth: string;       // auth: Authentication information portion (e.g. username:password).
         host: string;       // host: Host name with port number.
         hostname: string;   // hostname: Host name without port number.
         port: string;       // port: Optional port number.
@@ -22,6 +23,7 @@ declare module "url-parse" {
         query: Query;       // query: Parsed object containing query string, unless parsing is set to false.
         hash: string;       // hash: The "fragment" portion of the URL including the pound-sign (#).
         href: string;       // href: The full URL.
+        origin: string;     // origin: The origin of the URL.
 
         toString(): string;
         set(key: string, value: string|Object|number): ParsedUrl;

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "1.1.9",
   "description": "Small footprint URL parser that works seamlessly across Node.js and browser environments",
   "main": "index.js",
+  "typings": "index.d.ts",
   "scripts": {
     "100%": "istanbul check-coverage --statements 100 --functions 100 --lines 100 --branches 100",
     "browserify": "mkdir -p dist && browserify index.js -s URLParse -o dist/url-parse.js",


### PR DESCRIPTION
Resolves #46.

Adding this to `package.json` will allow typescript to find it without the need to add it to `@types`.