### PR TITLE
[fix] Return the base URL pathname when the relative URL is empty

### DIFF
--- a/index.js
+++ b/index.js
@@ -120,6 +120,8 @@ function extractProtocol(address) {
  * @private
  */
 function resolve(relative, base) {
+  if (relative === '') return base;
+
   var path = (base || '/').split('/').slice(0, -1).concat(relative.split('/'))
     , i = path.length
     , last = path[i - 1]

--- a/test/test.js
+++ b/test/test.js
@@ -497,6 +497,7 @@ describe('url-parse', function () {
       var tests = [
         ['', 'http://foo.com', ''],
         ['', 'http://foo.com/', '/'],
+        ['', 'http://foo.com/a', '/a'],
         ['a', 'http://foo.com', '/a'],
         ['a/', 'http://foo.com', '/a/'],
         ['b/c', 'http://foo.com/a', '/b/c'],


### PR DESCRIPTION
Fixes #157.