### PR TITLE
add test to cover + in email case

### DIFF
--- a/test/test.js
+++ b/test/test.js
@@ -114,6 +114,10 @@ describe('url-parse', function () {
 
     assume(data.query).is.a('object');
     assume(data.query).is.empty();
+
+    url = 'http://google.com?email=me+her@love.com';
+    assume(data.query).is.a('object');
+    assume(data.query.email).equals('me+her@love.com');
   });
 
   it('does not add question mark to href if query string is empty', function () {


### PR DESCRIPTION
I'm using Expo Linking.parse which relies on url-parse, and my url includes an email with this allowed form "x+y@xxx.com".
Decoding is incorrect as show by this additional test.