### PR TITLE
[security] More backslash fixes

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -33,13 +33,22 @@ acknowledge your responsible disclosure, if you wish.
 
 ## History
 
+> Using backslash in the protocol is valid in the browser, while url-parse
+> thinks it’s a relative path. An application that validates a url using
+> url-parse might pass a malicious link.
+
+- **Reporter credits**
+  - CxSCA AppSec team at Checkmarx.
+  - Twitter: [Yaniv Nizry](https://twitter.com/ynizry)
+- Fixed in: 1.5.0
+
 > The `extractProtocol` method does not return the correct protocol when
 > provided with unsanitized content which could lead to false positives.
 
 - **Reporter credits**
   - Reported through our security email & Twitter interaction.
   - Twitter: [@ronperris](https://twitter.com/ronperris)
-  - Fixed in: 1.4.5
+- Fixed in: 1.4.5
 
 ---
 

--- a/index.js
+++ b/index.js
@@ -2,8 +2,8 @@
 
 var required = require('requires-port')
   , qs = require('querystringify')
-  , slashes = /^[A-Za-z][A-Za-z0-9+-.]*:\/\//
-  , protocolre = /^([a-z][a-z0-9.+-]*:)?(\/\/)?([\S\s]*)/i
+  , slashes = /^[A-Za-z][A-Za-z0-9+-.]*:[\\/]+/
+  , protocolre = /^([a-z][a-z0-9.+-]*:)?([\\/]{1,})?([\S\s]*)/i
   , whitespace = '[\\x09\\x0A\\x0B\\x0C\\x0D\\x20\\xA0\\u1680\\u180E\\u2000\\u2001\\u2002\\u2003\\u2004\\u2005\\u2006\\u2007\\u2008\\u2009\\u200A\\u202F\\u205F\\u3000\\u2028\\u2029\\uFEFF]'
   , left = new RegExp('^'+ whitespace +'+');
 
@@ -115,11 +115,14 @@ function lolcation(loc) {
  */
 function extractProtocol(address) {
   address = trimLeft(address);
-  var match = protocolre.exec(address);
+
+  var match = protocolre.exec(address)
+    , protocol = match[1] ? match[1].toLowerCase() : ''
+    , slashes = !!(match[2] && match[2].length >= 2);
 
   return {
-    protocol: match[1] ? match[1].toLowerCase() : '',
-    slashes: !!match[2],
+    protocol: protocol,
+    slashes: slashes,
     rest: match[3]
   };
 }
@@ -278,6 +281,14 @@ function Url(address, location, parser) {
     && (url.pathname !== '' || location.pathname !== '')
   ) {
     url.pathname = resolve(url.pathname, location.pathname);
+  }
+
+  //
+  // Default to a / for pathname if none exists. This normalizes the URL
+  // to always have a /
+  //
+  if (url.pathname.charAt(0) !== '/' && url.hostname) {
+    url.pathname = '/' + url.pathname;
   }
 
   //

--- a/test/fuzzy.js
+++ b/test/fuzzy.js
@@ -103,6 +103,8 @@ module.exports = function generate() {
     , key;
 
   spec.protocol = get('protocol');
+  spec.slashes = true;
+  
   spec.hostname = get('hostname');
   spec.pathname = get('pathname');
 


### PR DESCRIPTION
As per title, it seems that the previous security fix released in 1.4.5 only partially fixed the issue, with this adjustment to the regular expression we now have parity with the browser built-in URL parser as well. This change also exposed an issue where we didn't default pathnames to / when nothing was supplied in URL's. 

That should now be resolved as well. 