### PR TITLE
[fix] Fixes relative path resolving #199 #200

### DIFF
--- a/index.js
+++ b/index.js
@@ -118,12 +118,13 @@ function extractProtocol(address) {
 
   var match = protocolre.exec(address)
     , protocol = match[1] ? match[1].toLowerCase() : ''
-    , slashes = !!(match[2] && match[2].length >= 2);
+    , slashes = !!(match[2] && match[2].length >= 2)
+    , rest =  match[2] && match[2].length === 1 ? '/' + match[3] : match[3];
 
   return {
     protocol: protocol,
     slashes: slashes,
-    rest: match[3]
+    rest: rest
   };
 }
 

--- a/test/test.js
+++ b/test/test.js
@@ -83,6 +83,20 @@ describe('url-parse', function () {
       });
     });
 
+    it('correctly resolves paths', function () {
+      assume(parse.extractProtocol('/foo')).eql({
+        slashes: false,
+        protocol: '',
+        rest: '/foo'
+      });
+
+      assume(parse.extractProtocol('//foo/bar')).eql({
+        slashes: true,
+        protocol: '',
+        rest: 'foo/bar'
+      });
+    });
+
     it('does not truncate the input string', function () {
       var input = 'foo\nbar\rbaz\u2028qux\u2029';
 
@@ -211,7 +225,7 @@ describe('url-parse', function () {
 
   it('correctly parses pathnames for relative paths', function () {
     var url = '/dataApi/PROD/ws'
-    , parsed = parse(url, 'http://localhost:3000/PROD/trends');
+     , parsed = parse(url, 'http://localhost:3000/PROD/trends');
 
     assume(parsed.pathname).equals('/dataApi/PROD/ws');
 

--- a/test/test.js
+++ b/test/test.js
@@ -209,6 +209,20 @@ describe('url-parse', function () {
     assume(parsed.href).equals('http://example.com/');
   });
 
+  it('correctly parses pathnames for relative paths', function () {
+    var url = '/dataApi/PROD/ws'
+    , parsed = parse(url, 'http://localhost:3000/PROD/trends');
+
+    assume(parsed.pathname).equals('/dataApi/PROD/ws');
+
+    url = '/sections/?project=default'
+    parsed = parse(url, 'http://example.com/foo/bar');
+
+    assume(parsed.pathname).equals('/sections/');
+    assume(parsed.hostname).equals('example.com');
+    assume(parsed.href).equals('http://example.com/sections/?project=default');
+  });
+
   it('does not care about spaces', function () {
     var url = 'http://x.com/path?that\'s#all, folks'
       , parsed = parse(url);


### PR DESCRIPTION
As per title, fixes the regression that was introduced in 1.5.0 by correctly prepending a / back into relative paths. 