### PR TITLE
[fix] Threat single forward/barckward slashes as double slashes extracting protocols

### DIFF
--- a/index.js
+++ b/index.js
@@ -117,9 +117,10 @@ function extractProtocol(address) {
   address = trimLeft(address);
 
   var match = protocolre.exec(address)
+    , slash = match[2] && !!match[2].length
     , protocol = match[1] ? match[1].toLowerCase() : ''
-    , slashes = !!(match[2] && match[2].length >= 2)
-    , rest =  match[2] && match[2].length === 1 ? '/' + match[3] : match[3];
+    , slashes = protocol && slash || !!(slash && match[2].length >= 2)
+    , rest = !slashes && slash && match[2].length === 1 ? '/' + match[3] : match[3];
 
   return {
     protocol: protocol,

--- a/test/test.js
+++ b/test/test.js
@@ -311,7 +311,7 @@ describe('url-parse', function () {
   });
 
   it('does not see a slash after the protocol as path', function () {
-    var url = 'https:\\github.com/foo/bar'
+    var url = 'https:\\/github.com/foo/bar'
       , parsed = parse(url);
 
     assume(parsed.host).equals('github.com');

--- a/test/test.js
+++ b/test/test.js
@@ -75,6 +75,22 @@ describe('url-parse', function () {
       });
     });
 
+    it('corrects a single forward slash to double slash', function () {
+      assume(parse.extractProtocol('https:/github.com/foo/bar')).eql({
+        slashes: true,
+        protocol: 'https:',
+        rest: 'github.com/foo/bar'
+      });
+    });
+
+    it('corrects a single backward slash to double slash', function () {
+      assume(parse.extractProtocol('https:\\github.com/foo/bar')).eql({
+        slashes: true,
+        protocol: 'https:',
+        rest: 'github.com/foo/bar'
+      });
+    });
+
     it('extracts the protocol data for nothing', function () {
       assume(parse.extractProtocol('')).eql({
         slashes: false,
@@ -283,8 +299,19 @@ describe('url-parse', function () {
     assume(parsed.href).equals('http://what-is-up.com/');
   });
 
+  it('does not see a single backslash as after protocol as path', function () {
+    var url = 'https:/github.com/foo/bar'
+      , parsed = parse(url);
+
+    assume(parsed.host).equals('github.com');
+    assume(parsed.hostname).equals('github.com');
+    assume(parsed.pathname).equals('/foo/bar');
+
+    assume(parsed.href).equals('https://github.com/foo/bar');
+  });
+
   it('does not see a slash after the protocol as path', function () {
-    var url = 'https:\\/github.com/foo/bar'
+    var url = 'https:\\github.com/foo/bar'
       , parsed = parse(url);
 
     assume(parsed.host).equals('github.com');


### PR DESCRIPTION
As per title, this ensures that `http:/whatever.com` and `http:\whatever.com` are both normalized to `http://` protocols. This allows the correct hostname and paths to be extracted from these invalid URL's

Fixes #206